### PR TITLE
Remove indent that can break extended source.

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,7 +309,7 @@ function renderFile(path, rootPath) {
 		pugOptions.filename = page.path;
 		if (page.data.layout) {
 			page.extended = `extends ${pugOptions.includes}/${page.data.layout}
-    ${page.content}`;
+${page.content}`;
 		} else {
 			page.extended = page.content;
 		}


### PR DESCRIPTION
It adds superfluous indent to the first line of pug `page.content`, so should be removed.